### PR TITLE
remove support limit, or make it higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "illuminate/support": "~5.7.0|~5.8.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",


### PR DESCRIPTION
e-granary on  master [⇡✘!] via ⬢ v12.18.0 via 🐘 v7.2.31 took 1m11s 
❯ composer require tumainimosha/laravel-coming-soon
Using version ^1.4 for tumainimosha/laravel-coming-soon
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for tumainimosha/laravel-coming-soon ^1.4 -> satisfiable by tumainimosha/laravel-coming-soon[1.4].
    - Conclusion: remove laravel/framework v7.15.0
    - Conclusion: don't install laravel/framework v7.15.0
    - tumainimosha/laravel-coming-soon 1.4 requires illuminate/support ~5.7.0|~5.8.0 -> satisfiable by illuminate/support[5.7.17, 5.7.18, 5.7.19, 5.7.x-dev, 5.8.x-dev, v5.7.0, v5.7.1, v5.7.10, v5.7.11, v5.7.15, v5.7.2, v5.7.20, v5.7.21, v5.7.22, v5.7.23, v5.7.26, v5.7.27, v5.7.28, v5.7.3, v5.7.4, v5.7.5, v5.7.6, v5.7.7, v5.7.8, v5.7.9, v5.8.0, v5.8.11, v5.8.12, v5.8.14, v5.8.15, v5.8.17, v5.8.18, v5.8.19, v5.8.2, v5.8.20, v5.8.22, v5.8.24, v5.8.27, v5.8.28, v5.8.29, v5.8.3, v5.8.30, v5.8.31, v5.8.32, v5.8.33, v5.8.34, v5.8.35, v5.8.36, v5.8.4, v5.8.8, v5.8.9].
    - don't install illuminate/support 5.7.17|don't install laravel/framework v7.15.0
    - don't install illuminate/support 5.7.18|don't install laravel/framework v7.15.0
    - don't install illuminate/support 5.7.19|don't install laravel/framework v7.15.0
    - don't install illuminate/support 5.7.x-dev|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.0|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.1|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.10|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.11|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.15|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.2|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.20|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.21|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.22|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.23|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.26|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.27|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.28|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.3|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.4|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.5|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.6|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.7|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.8|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.7.9|don't install laravel/framework v7.15.0
    - don't install illuminate/support 5.8.x-dev|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.0|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.11|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.12|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.14|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.15|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.17|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.18|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.19|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.2|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.20|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.22|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.24|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.27|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.28|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.29|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.3|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.30|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.31|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.32|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.33|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.34|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.35|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.36|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.4|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.8|don't install laravel/framework v7.15.0
    - don't install illuminate/support v5.8.9|don't install laravel/framework v7.15.0
    - Installation request for laravel/framework (locked at v7.15.0, required as ^7.0) -> satisfiable by laravel/framework[v7.15.0].


Installation failed, reverting ./composer.json to its original content.

e-granary on  master [⇡✘!] via ⬢ v12.18.0 via 🐘 v7.2.31 took 27s 
